### PR TITLE
Using new Andorid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
 
         <!-- Project depencies versions -->
         <aerogear.bom.version>0.2.4</aerogear.bom.version>
-        <android.version>4.4.2_r3</android.version>
+        <android.version>4.4.2_r4</android.version>
 
         <!-- Plugins versions -->
         <java.version>1.7</java.version>


### PR DESCRIPTION
Updating Android dependency.

Steps to test:
Update your SDK
Update your Maven SDK Deployer

delete ~/.m2/repository/android

run `mvn clean install` in the sdk deployer and then in -core.

If updating the SDK deployer fails, delete $ANDROID_HOME/add-ons/addon-google_apis-google-19-1 and rerun
