### PR TITLE
Dropping support for old Android versions

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          android:versionCode="1"
-          android:versionName="1.0"
           package="org.jboss.aerogear.android.core">
-
     <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21"/>
 </manifest>


### PR DESCRIPTION
We are dropping support for the old Android versions. For more informations see [Android Dashboard](https://developer.android.com/about/dashboards/index.html)

Jira: [AGDROID-310](https://issues.jboss.org/browse/AGDROID-310)
