### PR TITLE
Removing JDK 6 and bumping version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: android
 jdk:
   - oraclejdk8
   - oraclejdk7
-  - openjdk6
 
 notifications:
   irc: "irc.freenode.org#aerogear"

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.jboss.aerogear</groupId>
     <artifactId>aerogear-android-core</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>aar</packaging>
     <name>AeroGear Android Core Library</name>
     <url>http://aerogear.org</url>


### PR DESCRIPTION
As per discussions on #aerogear and aerogear-dev, we are removing support for JDK 6 which requires a bump to 3.0.0